### PR TITLE
Get project context

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,7 +25,7 @@ function updateProgress(patternId, questionsCount, progressElement) {
 // Function to load patterns data
 async function loadPatternsData() {
     try {
-        const response = await fetch('/content/patterns.json');
+        const response = await fetch('content/patterns.json');
         if (!response.ok) throw new Error('Failed to load patterns data');
         return await response.json();
     } catch (error) {
@@ -154,10 +154,10 @@ async function loadContent(pattern, problem) {
         
         // Construct paths for both possible formats
         const paths = [
-            `/content/${pattern}/${problem}/${language}.html`,  // without difficulty
-            `/content/${pattern}/${problem}-(easy)/${language}.html`,
-            `/content/${pattern}/${problem}-(medium)/${language}.html`,
-            `/content/${pattern}/${problem}-(hard)/${language}.html`
+            `content/${pattern}/${problem}/${language}.html`,  // without difficulty
+            `content/${pattern}/${problem}-(easy)/${language}.html`,
+            `content/${pattern}/${problem}-(medium)/${language}.html`,
+            `content/${pattern}/${problem}-(hard)/${language}.html`
         ];
         
         // Try each path until one works


### PR DESCRIPTION
Update fetch paths to be relative to fix content loading on GitHub Pages.

The previous absolute paths (e.g., `/content/patterns.json`) worked on localhost but caused 404 errors when hosted on GitHub Pages, as GitHub Pages serves the site from a subdirectory. Changing these to relative paths (e.g., `content/patterns.json`) resolves this issue.

---

[Open in Web](https://cursor.com/agents?id=bc-5acfdf5a-f1ca-48ed-83fc-cc300f5766dc) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5acfdf5a-f1ca-48ed-83fc-cc300f5766dc) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)